### PR TITLE
Add serverless-http dependency for Netlify deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^17.2.0",
         "express": "^4.18.2",
         "mssql": "^11.0.1",
+        "serverless-http": "^3.2.0",
         "twilio": "^5.8.0",
         "zod": "^3.23.8"
       },
@@ -11502,6 +11503,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serverless-http": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
+      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dotenv": "^17.2.0",
     "express": "^4.18.2",
     "mssql": "^11.0.1",
+    "serverless-http": "^3.2.0",
     "twilio": "^5.8.0",
     "zod": "^3.23.8"
   },


### PR DESCRIPTION
## Purpose

The user is experiencing deployment issues on Netlify with their GitHub code. The build process is completing successfully but they need to adapt their Express.js application to work in a serverless environment for proper Netlify deployment.

## Code changes

- Added `serverless-http` package (version ^3.2.0) as a dependency
- Updated both `package.json` and `package-lock.json` to include the new dependency
- This package enables Express.js applications to run in serverless environments like Netlify Functions

The `serverless-http` package will allow the Express.js server to be wrapped and deployed as serverless functions on Netlify, resolving the deployment compatibility issues.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/nova-home)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-nova-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>nova-home</branchName>-->