### PR TITLE
Fix Netlify deployment routing with conditional basename

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -21,7 +21,12 @@ const App = () => (
       <Toaster />
       <Sonner />
       <BrowserRouter
-        basename={import.meta.env.PROD ? "/aral-violet-wedding" : "/"}
+        basename={
+          import.meta.env.PROD &&
+          import.meta.env.VITE_DEPLOYMENT_PLATFORM !== "netlify"
+            ? "/aral-violet-wedding"
+            : "/"
+        }
       >
         <AuthProvider>
           <Routes>


### PR DESCRIPTION
## Purpose
The user was experiencing a blank page issue when deploying their application to Netlify. The build was completing successfully but the deployed site was not displaying content, indicating a routing configuration problem specific to the Netlify deployment platform.

## Code changes
- Modified the `BrowserRouter` basename configuration in `App.tsx` to conditionally handle different deployment platforms
- Added environment variable check for `VITE_DEPLOYMENT_PLATFORM` to detect Netlify deployments
- Set basename to "/" for Netlify deployments and "/aral-violet-wedding" for other production deployments
- This ensures proper routing behavior across different hosting platforms while maintaining existing functionality for non-Netlify deployments

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/flare-space)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-flare-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>flare-space</branchName>-->