### PR TITLE
Add RSVP duplicate validation and edit mode functionality

### DIFF
--- a/client/lib/database.ts
+++ b/client/lib/database.ts
@@ -73,7 +73,7 @@ export const guestService = {
 
   async update(
     id: string,
-    updates: Partial<Omit<SupabaseGuest, "id" | "created_at">>
+    updates: Partial<Omit<SupabaseGuest, "id" | "created_at">>,
   ): Promise<SupabaseGuest> {
     if (isSupabaseConfigured()) {
       try {
@@ -111,9 +111,12 @@ export const guestService = {
     return guest;
   },
 
-  updateInLocalStorage(id: string, updates: Partial<SupabaseGuest>): SupabaseGuest {
+  updateInLocalStorage(
+    id: string,
+    updates: Partial<SupabaseGuest>,
+  ): SupabaseGuest {
     const existing = this.getFromLocalStorage();
-    const index = existing.findIndex(guest => guest.id === id);
+    const index = existing.findIndex((guest) => guest.id === id);
 
     if (index === -1) {
       throw new Error("Guest not found for update");
@@ -348,7 +351,10 @@ export const invitationService = {
     return this.getFromLocalStorage();
   },
 
-  async upload(pdfData: string, filename?: string): Promise<SupabaseInvitation> {
+  async upload(
+    pdfData: string,
+    filename?: string,
+  ): Promise<SupabaseInvitation> {
     if (isSupabaseConfigured()) {
       try {
         // Delete existing invitation first (only keep the latest)
@@ -404,7 +410,10 @@ export const invitationService = {
         // Also remove from localStorage
         this.removeFromLocalStorage();
       } catch (error) {
-        console.warn("Supabase unavailable, removing from localStorage:", error);
+        console.warn(
+          "Supabase unavailable, removing from localStorage:",
+          error,
+        );
         this.removeFromLocalStorage();
       }
     } else {

--- a/client/pages/AdminDashboard.tsx
+++ b/client/pages/AdminDashboard.tsx
@@ -2277,19 +2277,28 @@ export default function AdminDashboard() {
 
                                   toast({
                                     title: "Invitation Removed! 🗑️",
-                                    description: "Custom invitation has been removed. Guests will now download the default text invitation.",
+                                    description:
+                                      "Custom invitation has been removed. Guests will now download the default text invitation.",
                                     duration: 3000,
                                   });
                                 } catch (error) {
-                                  console.error("Error removing invitation:", error);
+                                  console.error(
+                                    "Error removing invitation:",
+                                    error,
+                                  );
                                   // Fallback to local removal
                                   setInvitationPDF(null);
-                                  localStorage.removeItem("wedding_invitation_pdf");
-                                  localStorage.removeItem("wedding_invitation_filename");
+                                  localStorage.removeItem(
+                                    "wedding_invitation_pdf",
+                                  );
+                                  localStorage.removeItem(
+                                    "wedding_invitation_filename",
+                                  );
 
                                   toast({
                                     title: "Invitation Removed! 🗑️",
-                                    description: "Custom invitation has been removed locally.",
+                                    description:
+                                      "Custom invitation has been removed locally.",
                                     duration: 3000,
                                   });
                                 }

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -228,7 +228,8 @@ export default function Index() {
       );
 
       // Find any existing RSVP for editing
-      const existingGuest = duplicateByName || duplicateByEmail || duplicateByPhone;
+      const existingGuest =
+        duplicateByName || duplicateByEmail || duplicateByPhone;
 
       if (existingGuest && !isEditMode) {
         // Switch to edit mode and populate form with existing data
@@ -266,7 +267,9 @@ export default function Index() {
       }
 
       console.log(
-        isEditMode ? "Updating existing RSVP with side:" : "Creating new RSVP with side:",
+        isEditMode
+          ? "Updating existing RSVP with side:"
+          : "Creating new RSVP with side:",
         rsvpForm.side,
       );
 
@@ -333,7 +336,9 @@ export default function Index() {
       }
 
       toast({
-        title: isEditMode ? "RSVP Updated Successfully! ✏️" : "RSVP Submitted Successfully! 🎉",
+        title: isEditMode
+          ? "RSVP Updated Successfully! ✏️"
+          : "RSVP Submitted Successfully! 🎉",
         description: isEditMode
           ? `Thank you ${rsvpForm.name}! Your RSVP has been updated successfully.${database.isUsingSupabase() ? " ✨ Synced across all devices!" : ""}`
           : `Thank you ${rsvpForm.name}! We can't wait to celebrate with you on December 28, 2025!${database.isUsingSupabase() ? " ✨ Synced across all devices!" : ""}`,
@@ -371,7 +376,8 @@ export default function Index() {
         );
 
         // Find any existing RSVP for editing in localStorage
-        const existingLocalGuest = duplicateByName || duplicateByEmail || duplicateByPhone;
+        const existingLocalGuest =
+          duplicateByName || duplicateByEmail || duplicateByPhone;
 
         if (existingLocalGuest && !isEditMode) {
           // Switch to edit mode and populate form with existing data
@@ -397,7 +403,11 @@ export default function Index() {
           return;
         }
 
-        if (existingLocalGuest && isEditMode && existingLocalGuest.id !== editingGuestId) {
+        if (
+          existingLocalGuest &&
+          isEditMode &&
+          existingLocalGuest.id !== editingGuestId
+        ) {
           // Trying to edit but conflicting with a different guest
           toast({
             title: "Conflict Detected! ❌",
@@ -423,7 +433,7 @@ export default function Index() {
                   dietaryRestrictions: rsvpForm.dietaryRestrictions,
                   needsAccommodation: rsvpForm.needsAccommodation,
                 }
-              : guest
+              : guest,
           );
           console.log("RSVP updated in localStorage fallback");
         } else {
@@ -439,7 +449,9 @@ export default function Index() {
         localStorage.setItem("wedding_guests", JSON.stringify(updatedGuests));
 
         toast({
-          title: isEditMode ? "RSVP Updated Successfully! ✏️" : "RSVP Submitted Successfully! 🎉",
+          title: isEditMode
+            ? "RSVP Updated Successfully! ✏️"
+            : "RSVP Submitted Successfully! 🎉",
           description: isEditMode
             ? `Thank you ${rsvpForm.name}! Your RSVP has been updated successfully.`
             : `Thank you ${rsvpForm.name}! Your RSVP has been saved. We can't wait to celebrate with you!`,
@@ -585,16 +597,20 @@ Made with love ❤️ By Aral D'Souza
           // Download the uploaded PDF invitation
           const link = document.createElement("a");
           link.href = uploadedInvitation.pdf_data;
-          link.download = uploadedInvitation.filename || "Aral-Violet-Wedding-Invitation.pdf";
+          link.download =
+            uploadedInvitation.filename || "Aral-Violet-Wedding-Invitation.pdf";
           link.click();
 
           toast({
             title: "Invitation Downloaded! 💌",
-            description: "Your beautiful wedding invitation PDF has been downloaded successfully.",
+            description:
+              "Your beautiful wedding invitation PDF has been downloaded successfully.",
             duration: 3000,
           });
 
-          console.log("Uploaded invitation PDF downloaded successfully from admin");
+          console.log(
+            "Uploaded invitation PDF downloaded successfully from admin",
+          );
           return;
         }
       } catch (dbError) {
@@ -619,7 +635,9 @@ Made with love ❤️ By Aral D'Souza
           duration: 3000,
         });
 
-        console.log("Wedding invitation PDF downloaded successfully from server");
+        console.log(
+          "Wedding invitation PDF downloaded successfully from server",
+        );
         return;
       }
 
@@ -637,7 +655,8 @@ Made with love ❤️ By Aral D'Souza
 
           toast({
             title: "Invitation Downloaded! ���",
-            description: "Your beautiful wedding invitation PDF has been downloaded successfully.",
+            description:
+              "Your beautiful wedding invitation PDF has been downloaded successfully.",
             duration: 3000,
           });
 
@@ -660,7 +679,8 @@ Made with love ❤️ By Aral D'Souza
 
           toast({
             title: "Invitation Downloaded! 💌",
-            description: "Your beautiful wedding invitation PDF has been downloaded successfully.",
+            description:
+              "Your beautiful wedding invitation PDF has been downloaded successfully.",
             duration: 3000,
           });
 
@@ -723,7 +743,8 @@ Please RSVP at our wedding website
 
       toast({
         title: "Download Error ❌",
-        description: "There was an error downloading the invitation. Please try again.",
+        description:
+          "There was an error downloading the invitation. Please try again.",
         variant: "destructive",
         duration: 3000,
       });
@@ -1193,7 +1214,8 @@ Please RSVP at our wedding website
 
               {isEditMode && (
                 <div className="bg-blue-100 border border-blue-300 text-blue-700 px-4 py-3 rounded mb-6">
-                  📝 <strong>Edit Mode:</strong> You're updating your existing RSVP. Name and email are locked for security.
+                  📝 <strong>Edit Mode:</strong> You're updating your existing
+                  RSVP. Name and email are locked for security.
                 </div>
               )}
 
@@ -1207,34 +1229,46 @@ Please RSVP at our wedding website
                 <div className="grid md:grid-cols-2 gap-4">
                   <div>
                     <label className="block text-sm font-medium text-sage-700 mb-2">
-                      Your Name(s) * {isEditMode && <span className="text-xs text-blue-600">(Read-only)</span>}
+                      Your Name(s) *{" "}
+                      {isEditMode && (
+                        <span className="text-xs text-blue-600">
+                          (Read-only)
+                        </span>
+                      )}
                     </label>
                     <Input
                       type="text"
                       value={rsvpForm.name}
                       onChange={(e) =>
-                        !isEditMode && setRsvpForm({ ...rsvpForm, name: e.target.value })
+                        !isEditMode &&
+                        setRsvpForm({ ...rsvpForm, name: e.target.value })
                       }
                       placeholder="Enter your name(s)"
                       required
                       readOnly={isEditMode}
-                      className={`border-sage-300 focus:border-olive-500 ${isEditMode ? 'bg-gray-100 cursor-not-allowed' : ''}`}
+                      className={`border-sage-300 focus:border-olive-500 ${isEditMode ? "bg-gray-100 cursor-not-allowed" : ""}`}
                     />
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-sage-700 mb-2">
-                      Email Address * {isEditMode && <span className="text-xs text-blue-600">(Read-only)</span>}
+                      Email Address *{" "}
+                      {isEditMode && (
+                        <span className="text-xs text-blue-600">
+                          (Read-only)
+                        </span>
+                      )}
                     </label>
                     <Input
                       type="email"
                       value={rsvpForm.email}
                       onChange={(e) =>
-                        !isEditMode && setRsvpForm({ ...rsvpForm, email: e.target.value })
+                        !isEditMode &&
+                        setRsvpForm({ ...rsvpForm, email: e.target.value })
                       }
                       placeholder="Enter your email"
                       required
                       readOnly={isEditMode}
-                      className={`border-sage-300 focus:border-olive-500 ${isEditMode ? 'bg-gray-100 cursor-not-allowed' : ''}`}
+                      className={`border-sage-300 focus:border-olive-500 ${isEditMode ? "bg-gray-100 cursor-not-allowed" : ""}`}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Purpose

Enhance the RSVP form to prevent duplicate submissions by validating against name, email, and phone number. When a duplicate is detected, allow users to edit their existing RSVP instead of creating a new entry. In edit mode, name and email fields become read-only for security while other fields remain editable.

## Code changes

- **Database service enhancements**: Added `update()` and `updateInLocalStorage()` methods to `guestService` for updating existing RSVP entries
- **Invitation service**: Added complete `invitationService` with CRUD operations for managing wedding invitation PDFs, supporting both Supabase and localStorage
- **Admin dashboard**: Updated invitation management to use the new database service instead of direct localStorage access
- **RSVP form**: 
  - Added edit mode UI with read-only name/email fields
  - Added visual indicators for edit mode vs new submission
  - Added cancel edit functionality to return to new RSVP mode
  - Updated form submission button text based on mode
- **Invitation download**: Enhanced download logic with fallback priority system (uploaded PDF → server endpoint → API → localStorage → text fallback)
- **Error handling**: Improved error handling and user feedback throughout the invitation and RSVP workflows

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/echo-nest)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-echo-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>echo-nest</branchName>-->