### PR TITLE
Fix SMS debug endpoint for Netlify deployment

### DIFF
--- a/client/pages/Debug.tsx
+++ b/client/pages/Debug.tsx
@@ -132,7 +132,12 @@ export default function Debug() {
 
   const debugSMSDetailed = async () => {
     try {
-      const response = await fetch("/api/sms/debug");
+      // Use appropriate endpoint based on deployment
+      const debugUrl = import.meta.env.VITE_DEPLOYMENT_PLATFORM === "netlify"
+        ? "/.netlify/functions/sms-debug"
+        : "/api/sms/debug";
+
+      const response = await fetch(debugUrl);
       const data = await response.json();
       setSmsDebugStatus(data);
     } catch (error: any) {

--- a/client/pages/Debug.tsx
+++ b/client/pages/Debug.tsx
@@ -133,9 +133,10 @@ export default function Debug() {
   const debugSMSDetailed = async () => {
     try {
       // Use appropriate endpoint based on deployment
-      const debugUrl = import.meta.env.VITE_DEPLOYMENT_PLATFORM === "netlify"
-        ? "/.netlify/functions/sms-debug"
-        : "/api/sms/debug";
+      const debugUrl =
+        import.meta.env.VITE_DEPLOYMENT_PLATFORM === "netlify"
+          ? "/.netlify/functions/sms-debug"
+          : "/api/sms/debug";
 
       const response = await fetch(debugUrl);
       const data = await response.json();

--- a/netlify/functions/sms-debug.ts
+++ b/netlify/functions/sms-debug.ts
@@ -1,0 +1,109 @@
+import { Handler } from "@netlify/functions";
+import twilio from "twilio";
+
+export const handler: Handler = async (event, context) => {
+  // Enable CORS
+  const headers = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Content-Type": "application/json",
+  };
+
+  // Handle CORS preflight
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 200,
+      headers,
+      body: "",
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: "Method not allowed" }),
+    };
+  }
+
+  try {
+    const accountSid = process.env.TWILIO_ACCOUNT_SID;
+    const authToken = process.env.TWILIO_AUTH_TOKEN;
+    const fromNumber = process.env.TWILIO_PHONE_NUMBER;
+
+    const debug = {
+      environment: {
+        hasSid: !!accountSid,
+        hasToken: !!authToken,
+        hasPhone: !!fromNumber,
+        sidPrefix: accountSid ? accountSid.substring(0, 6) + "..." : "Not set",
+        phoneNumber: fromNumber || "Not set",
+      },
+      credentials: {},
+      twilioTest: {},
+    };
+
+    // Test Twilio client initialization
+    try {
+      if (accountSid && authToken) {
+        const client = twilio(accountSid, authToken);
+        debug.credentials.clientInitialized = true;
+
+        // Try to fetch account info to validate credentials
+        try {
+          const account = await client.api.accounts(accountSid).fetch();
+          debug.credentials.accountValid = true;
+          debug.credentials.accountStatus = account.status;
+          debug.credentials.accountFriendlyName = account.friendlyName;
+        } catch (error: any) {
+          debug.credentials.accountValid = false;
+          debug.credentials.accountError = error.message;
+          debug.credentials.errorCode = error.code;
+        }
+
+        // Test phone number validation
+        if (fromNumber) {
+          try {
+            const phoneNumbers = await client.incomingPhoneNumbers.list();
+            const ownedNumber = phoneNumbers.find(
+              (p) => p.phoneNumber === fromNumber,
+            );
+            debug.twilioTest.phoneNumberOwned = !!ownedNumber;
+            debug.twilioTest.totalOwnedNumbers = phoneNumbers.length;
+            debug.twilioTest.ownedNumbers = phoneNumbers.map(
+              (p) => p.phoneNumber,
+            );
+          } catch (error: any) {
+            debug.twilioTest.phoneNumberError = error.message;
+          }
+        }
+      } else {
+        debug.credentials.clientInitialized = false;
+        debug.credentials.missingVars = [];
+        if (!accountSid)
+          debug.credentials.missingVars.push("TWILIO_ACCOUNT_SID");
+        if (!authToken) debug.credentials.missingVars.push("TWILIO_AUTH_TOKEN");
+        if (!fromNumber)
+          debug.credentials.missingVars.push("TWILIO_PHONE_NUMBER");
+      }
+    } catch (error: any) {
+      debug.credentials.initError = error.message;
+    }
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify(debug),
+    };
+  } catch (error: any) {
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({
+        error: "Debug failed",
+        message: error.message,
+      }),
+    };
+  }
+};

--- a/netlify/functions/sms-debug.ts
+++ b/netlify/functions/sms-debug.ts
@@ -32,7 +32,7 @@ export const handler: Handler = async (event, context) => {
     const authToken = process.env.TWILIO_AUTH_TOKEN;
     const fromNumber = process.env.TWILIO_PHONE_NUMBER;
 
-    const debug = {
+    const debug: any = {
       environment: {
         hasSid: !!accountSid,
         hasToken: !!authToken,


### PR DESCRIPTION
## Purpose

The user was experiencing SMS debugging issues where the debug endpoint was returning HTML instead of JSON, causing a parsing error ("Unexpected token '<', "<!doctype "... is not valid JSON"). This was happening because the SMS debug functionality wasn't properly configured for Netlify deployments, where serverless functions use different routing patterns than traditional API endpoints.

## Code changes

- **Updated Debug.tsx**: Modified the SMS debug function to use environment-aware endpoint routing, checking `VITE_DEPLOYMENT_PLATFORM` to determine whether to use Netlify Functions (`/.netlify/functions/sms-debug`) or standard API routes (`/api/sms/debug`)

- **Added sms-debug.ts**: Created a new Netlify Function that provides comprehensive SMS debugging capabilities including:
  - Environment variable validation for Twilio credentials
  - Twilio client initialization testing
  - Account validation and status checking
  - Phone number ownership verification
  - Proper CORS headers for cross-origin requests
  - Error handling with detailed debug information

This ensures SMS debugging works correctly across different deployment platforms while providing detailed diagnostic information for troubleshooting Twilio integration issues.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/stellar-garden)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-stellar-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>stellar-garden</branchName>-->