### PR TITLE
Optimize SMS message length for Twilio trial account

### DIFF
--- a/netlify/functions/sms-send-rsvp-notification.ts
+++ b/netlify/functions/sms-send-rsvp-notification.ts
@@ -72,20 +72,8 @@ export const handler: Handler = async (event, context) => {
     const sideText =
       rsvpDetails.side === "groom" ? "Aral's side" : "Violet's side";
 
-    const message = `🎉 NEW RSVP RECEIVED! 
-
-👤 Name: ${rsvpDetails.name}
-📧 Email: ${rsvpDetails.email}
-📱 Phone: ${rsvpDetails.phone}
-${attendingText}
-👥 Guests: ${rsvpDetails.guests}
-👨‍👩‍👧‍👦 Side: ${sideText}
-
-${rsvpDetails.message ? `💬 Message: ${rsvpDetails.message}` : ""}
-${rsvpDetails.dietaryRestrictions ? `🍽️ Dietary: ${rsvpDetails.dietaryRestrictions}` : ""}
-${rsvpDetails.needsAccommodation ? "🏨 Needs Accommodation: Yes" : ""}
-
-TheVIRALWedding - A&V 💕`;
+    // Create optimized message for trial account (under 160 chars to avoid segments)
+    const message = `RSVP: ${rsvpDetails.name} ${attendingText} +${rsvpDetails.guests} guests (${sideText}) - A&V Wedding`;
 
     console.log(
       "📱 SMS Message to be sent to",

--- a/server/routes/sms.ts
+++ b/server/routes/sms.ts
@@ -48,20 +48,8 @@ export const sendRSVPSMSNotification = async (req: Request, res: Response) => {
     const sideText =
       rsvpDetails.side === "groom" ? "Aral's side" : "Violet's side";
 
-    const message = `🎉 NEW RSVP RECEIVED! 
-
-👤 Name: ${rsvpDetails.name}
-📧 Email: ${rsvpDetails.email}
-📱 Phone: ${rsvpDetails.phone}
-${attendingText}
-👥 Guests: ${rsvpDetails.guests}
-👨‍👩‍👧‍👦 Side: ${sideText}
-
-${rsvpDetails.message ? `💬 Message: ${rsvpDetails.message}` : ""}
-${rsvpDetails.dietaryRestrictions ? `🍽️ Dietary: ${rsvpDetails.dietaryRestrictions}` : ""}
-${rsvpDetails.needsAccommodation ? "🏨 Needs Accommodation: Yes" : ""}
-
-TheVIRALWedding - A&V 💕`;
+    // Create optimized message for trial account (under 160 chars to avoid segments)
+    const message = `RSVP: ${rsvpDetails.name} ${attendingText} +${rsvpDetails.guests} guests (${sideText}) - A&V Wedding`;
 
     console.log(
       "📱 SMS Message to be sent to",


### PR DESCRIPTION
## Purpose

The user encountered a Twilio trial account limitation where their RSVP notification SMS exceeded the message length limit, resulting in multiple message segments and a "Trial Message Length Exceeded" warning. The original message was 4 segments long, which impacts cost and delivery reliability on trial accounts.

## Code changes

- **Simplified SMS message format**: Replaced the detailed multi-line RSVP notification message with a concise single-line format
- **Reduced message length**: Changed from a 4-segment message to under 160 characters to avoid segmentation
- **Preserved essential information**: Kept core RSVP details (name, attendance status, guest count, side) while removing emojis and extra formatting
- **Updated both endpoints**: Applied the same optimization to both the Netlify function and server route for consistency
- **Added explanatory comments**: Included comments explaining the optimization for trial account compatibility

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/echo-field)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-echo-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>echo-field</branchName>-->