### PR TITLE
Remove developer debug section from photo gallery

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1612,28 +1612,6 @@ Please RSVP at our wedding website
                   We're still preparing our photo gallery. Check back soon to
                   see our beautiful memories!
                 </p>
-
-                {/* Configuration notice for developers */}
-                <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-lg max-w-md mx-auto">
-                  <p className="text-sm text-blue-700 mb-2">
-                    🔧 <strong>For Developers:</strong> If you have photos in
-                    Supabase but they're not showing:
-                  </p>
-                  <div className="space-x-2">
-                    <a
-                      href="/test-photos"
-                      className="inline-block bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-xs transition-colors"
-                    >
-                      Test Connection
-                    </a>
-                    <a
-                      href="/login"
-                      className="inline-block bg-olive-600 hover:bg-olive-700 text-white px-3 py-1 rounded text-xs transition-colors"
-                    >
-                      Admin Panel
-                    </a>
-                  </div>
-                </div>
               </CardContent>
             </Card>
           )}


### PR DESCRIPTION
## Purpose
The user requested to remove the developer debug section from the photo gallery since the application is now in production. The photos are displaying correctly and the debugging tools are no longer needed for the live wedding website.

## Code changes
- Removed the blue developer notice box from the photo gallery section
- Deleted the "Test Connection" and "Admin Panel" debug buttons
- Cleaned up the developer-specific messaging that was meant for troubleshooting Supabase photo display issues

The photo gallery now shows only the placeholder message without any development/debugging UI elements.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/cosmos-lab)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-cosmos-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>cosmos-lab</branchName>-->