### PR TITLE
Simplify photos.ts env config to match guest.ts

### DIFF
--- a/server/routes/photos.ts
+++ b/server/routes/photos.ts
@@ -47,55 +47,22 @@ export const validateGuestUpload: RequestHandler = async (req, res, next) => {
   }
 };
 
-// Supabase configuration - check all possible environment variable sources
-const supabaseUrl =
-  process.env.SUPABASE_URL ||
-  process.env.VITE_SUPABASE_URL ||
-  process.env.REACT_APP_SUPABASE_URL ||
-  "";
-const supabaseKey =
-  process.env.SUPABASE_ANON_KEY ||
-  process.env.VITE_SUPABASE_ANON_KEY ||
-  process.env.REACT_APP_SUPABASE_ANON_KEY ||
-  "";
+// Supabase configuration
+const supabaseUrl = process.env.VITE_SUPABASE_URL || "";
+const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY || "";
 
 let supabase: any = null;
-if (
-  supabaseUrl &&
-  supabaseKey &&
-  supabaseUrl !== "YOUR_SUPABASE_URL" &&
-  supabaseKey !== "YOUR_SUPABASE_ANON_KEY" &&
-  supabaseUrl !== "https://yourproject.supabase.co" &&
-  supabaseKey !== "your_anon_key_here" &&
-  supabaseUrl.includes("supabase.co")
-) {
+if (supabaseUrl && supabaseKey) {
   try {
     supabase = createClient(supabaseUrl, supabaseKey);
     console.log("✅ Supabase client initialized for photos service");
-    console.log("📊 Supabase URL:", supabaseUrl.substring(0, 50) + "...");
-    console.log("🔑 Supabase Key:", supabaseKey.substring(0, 20) + "...");
   } catch (error) {
     console.warn("❌ Failed to initialize Supabase for photos:", error);
   }
 } else {
   console.warn(
-    "⚠️ Supabase credentials not properly configured - photos service will use fallback mock data",
+    "⚠️ Supabase credentials not found - photos service will use fallback",
   );
-  console.log("📋 Environment check:", {
-    NODE_ENV: process.env.NODE_ENV,
-    SUPABASE_URL: process.env.SUPABASE_URL
-      ? `${process.env.SUPABASE_URL.substring(0, 30)}...`
-      : "not set",
-    VITE_SUPABASE_URL: process.env.VITE_SUPABASE_URL
-      ? `${process.env.VITE_SUPABASE_URL.substring(0, 30)}...`
-      : "not set",
-    SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY ? "set" : "not set",
-    VITE_SUPABASE_ANON_KEY: process.env.VITE_SUPABASE_ANON_KEY
-      ? "set"
-      : "not set",
-    detectedUrl: supabaseUrl || "none",
-    detectedKey: supabaseKey ? "present" : "missing",
-  });
 }
 
 // Get all photos with optional filtering by uploader type


### PR DESCRIPTION
## Purpose
The user wanted to standardize the environment variable configuration in `photos.ts` to match the simpler approach used in `guest.ts`, since both services use the same Supabase configuration and the guest functionality is working properly.

## Code changes
- **Simplified environment variable detection**: Removed fallback checks for multiple env variable naming conventions (`SUPABASE_URL`, `REACT_APP_SUPABASE_URL`) and now only uses `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
- **Streamlined validation logic**: Removed complex validation checks for placeholder values and URL format validation
- **Reduced logging**: Removed verbose environment debugging logs and credential substring logging for cleaner output
- **Simplified error messaging**: Updated warning message to be more concise

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 34`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/quantum-realm)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-quantum-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>quantum-realm</branchName>-->