### PR TITLE
Remove Supabase connection test from photos endpoint

### DIFF
--- a/server/routes/photos.ts
+++ b/server/routes/photos.ts
@@ -76,34 +76,6 @@ export const getPhotos: RequestHandler = async (req, res) => {
     if (supabase) {
       console.log("📸 Using Supabase for photos");
 
-      // Test Supabase connection with better error handling
-      try {
-        const { data: testData, error: testError } = await supabase
-          .from("photos")
-          .select("count", { count: "exact", head: true })
-          .limit(1);
-
-        if (testError) {
-          console.error("📸 Supabase connection test failed:", {
-            message: testError.message,
-            details: testError.details,
-            hint: testError.hint,
-            code: testError.code,
-          });
-          throw testError;
-        }
-
-        console.log("📸 Supabase connection successful, query test passed");
-      } catch (connectionError) {
-        console.error("📸 Supabase connection failed:", {
-          message: connectionError.message,
-          details: connectionError.details || connectionError.toString(),
-          hint: connectionError.hint || "",
-          code: connectionError.code || "",
-        });
-        throw connectionError;
-      }
-
       let query = supabase
         .from("photos")
         .select("*")


### PR DESCRIPTION
## Purpose

Based on the conversation history, users were experiencing issues with photo saving and retrieval functionality. The team identified that while other data operations (guests, invitations) were working properly with the database, photos specifically were not being saved and retrieved correctly. The investigation revealed that Supabase connection was already properly configured in Netlify, and the issue was likely related to unnecessary connection testing code interfering with the photo operations.

## Code Changes

- **Removed Supabase connection test code** from the `getPhotos` endpoint in `server/routes/photos.ts`
- Eliminated the test query that was checking table count before actual photo operations
- Removed associated error handling and logging for the connection test
- Streamlined the photos query to execute directly without preliminary connection validation

This change removes 28 lines of connection testing code that was potentially causing interference with photo operations, allowing the endpoint to function more efficiently like the working guests and invitations endpoints.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/mystic-world)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-mystic-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>mystic-world</branchName>-->