### PR TITLE
Replace @radix-ui/react-button with @radix-ui/react-slot

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig(({ mode }) => ({
           ui: [
             "@radix-ui/react-accordion",
             "@radix-ui/react-dialog",
-            "@radix-ui/react-button",
+            "@radix-ui/react-slot",
           ],
           utils: ["clsx", "date-fns", "lucide-react"],
         },


### PR DESCRIPTION
## Purpose
Based on the build logs showing dependency issues and engine warnings, this change updates the Radix UI dependencies to resolve compatibility problems with the current Node.js version (v18.20.8) and improve the build process.

## Code changes
- Updated Vite configuration to replace `@radix-ui/react-button` with `@radix-ui/react-slot` in the UI dependencies array
- This change affects the external dependency bundling configuration in `vite.config.ts`

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 41`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/zenith-realm)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-zenith-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>zenith-realm</branchName>-->