### PR TITLE
Fix invitation download by updating database import

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -25,7 +25,7 @@ import {
   weddingFlowApi,
   handleApiError,
 } from "@/lib/api";
-import { database } from "@/lib/database-simple";
+import { database } from "@/lib/database";
 import { sendRSVPNotification, isSMSConfigured } from "@/lib/sms-service";
 import {
   mobileOptimizedDownload,


### PR DESCRIPTION
## Purpose
Fix the download invitation button functionality that was not properly retrieving invitation data from the database due to an incorrect database import reference.

## Code changes
- Updated database import in `client/pages/Index.tsx` from `@/lib/database-simple` to `@/lib/database`
- This ensures the invitation download feature uses the correct database connection to retrieve invitation data

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`

🔗 [Edit in Builder.io](https://builder.io/app/projects/99c01001bffc45f9ad5ce1d6141380ab/pulse-den)

👀 [Preview Link](https://99c01001bffc45f9ad5ce1d6141380ab-pulse-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>99c01001bffc45f9ad5ce1d6141380ab</projectId>-->
<!--<branchName>pulse-den</branchName>-->