### PR TITLE
Fix PDF invitation download data format handling

### DIFF
--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -479,7 +479,7 @@ export default function Index() {
           ? "RSVP Updated Successfully! ��️"
           : "RSVP Submitted Successfully! 🎉",
         description: isEditMode
-          ? `Thank you ${rsvpForm.name}! Your RSVP has been updated successfully.${database.isUsingSupabase() ? " �� Synced across all devices!" : ""}`
+          ? `Thank you ${rsvpForm.name}! Your RSVP has been updated successfully.${database.isUsingSupabase() ? " ✨ Synced across all devices!" : ""}`
           : `Thank you ${rsvpForm.name}! We can't wait to celebrate with you on December 28, 2025!${database.isUsingSupabase() ? " ✨ Synced across all devices!" : ""}`,
         duration: 5000,
       });
@@ -876,6 +876,9 @@ Made with love ❤️ By Aral D'Souza
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);
+            if (typeof dataForDownload !== "string" && link.href.startsWith("blob:")) {
+              URL.revokeObjectURL(link.href);
+            }
             console.log("📱 Standard download method executed");
           }
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -479,7 +479,7 @@ export default function Index() {
           ? "RSVP Updated Successfully! ��️"
           : "RSVP Submitted Successfully! 🎉",
         description: isEditMode
-          ? `Thank you ${rsvpForm.name}! Your RSVP has been updated successfully.${database.isUsingSupabase() ? " ✨ Synced across all devices!" : ""}`
+          ? `Thank you ${rsvpForm.name}! Your RSVP has been updated successfully.${database.isUsingSupabase() ? " �� Synced across all devices!" : ""}`
           : `Thank you ${rsvpForm.name}! We can't wait to celebrate with you on December 28, 2025!${database.isUsingSupabase() ? " ✨ Synced across all devices!" : ""}`,
         duration: 5000,
       });
@@ -857,7 +857,12 @@ Made with love ❤️ By Aral D'Souza
             // Fallback to standard download method
             console.log("📱 Mobile download failed, using standard method...");
             const link = document.createElement("a");
-            link.href = uploadedInvitation.pdf_data;
+            if (typeof dataForDownload === "string") {
+              link.href = dataForDownload;
+            } else {
+              const objectUrl = URL.createObjectURL(dataForDownload);
+              link.href = objectUrl;
+            }
             link.download = filename;
             link.target = "_blank";
 
@@ -903,7 +908,7 @@ Made with love ❤️ By Aral D'Souza
       }
 
       // Second priority: Try the server endpoint (which has its own fallback logic)
-      console.log("���� Trying server endpoint as fallback...");
+      console.log("🌐 Trying server endpoint as fallback...");
       const isNetlify = import.meta.env.VITE_DEPLOYMENT_PLATFORM === "netlify";
       const downloadEndpoint = isNetlify
         ? "/.netlify/functions/download-invitation"
@@ -1591,7 +1596,7 @@ Please RSVP at our wedding website
                         decoding="async"
                       />
                       <p className="text-sm font-medium text-olive-700 mb-2">
-                        ���� Scan to Upload Couple Photos
+                        📸 Scan to Upload Couple Photos
                       </p>
                       <p className="text-xs text-sage-500 mb-3">
                         Point your camera here

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1005,6 +1005,9 @@ Made with love ❤️ By Aral D'Souza
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);
+            if (typeof dataForDownload !== "string" && link.href.startsWith("blob:")) {
+              URL.revokeObjectURL(link.href);
+            }
           }
 
           toast({

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -923,12 +923,15 @@ Made with love ❤️ By Aral D'Souza
         const url = window.URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = url;
-        link.download = "Aral-Violet-Wedding-Invitation.pdf";
+        const disposition = response.headers.get("content-disposition") || "";
+        const match = disposition.match(/filename="?([^";]+)"?/i);
+        const serverFilename = match ? match[1] : "Aral-Violet-Wedding-Invitation.pdf";
+        link.download = serverFilename;
         link.target = "_blank";
 
         // Use mobile-optimized download utility
         const downloadSuccess = mobileOptimizedDownload(blob, {
-          filename: "Aral-Violet-Wedding-Invitation.pdf",
+          filename: serverFilename,
           mimeType: "application/pdf",
         });
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -833,14 +833,18 @@ Made with love ❤️ By Aral D'Souza
               for (let i = 0; i < byteChars.length; i++)
                 byteNums[i] = byteChars.charCodeAt(i);
               const byteArray = new Uint8Array(byteNums);
-              dataForDownload = new Blob([byteArray], { type: "application/pdf" });
+              dataForDownload = new Blob([byteArray], {
+                type: "application/pdf",
+              });
             } catch {
               dataForDownload = `data:application/pdf;base64,${dataForDownload}`;
             }
           }
 
           // Download the uploaded PDF invitation - Mobile-friendly approach
-          console.log("📱 Attempting mobile-optimized download from database...");
+          console.log(
+            "📱 Attempting mobile-optimized download from database...",
+          );
 
           const filename =
             uploadedInvitation.filename || "Aral-Violet-Wedding-Invitation.pdf";
@@ -876,7 +880,10 @@ Made with love ❤️ By Aral D'Souza
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);
-            if (typeof dataForDownload !== "string" && link.href.startsWith("blob:")) {
+            if (
+              typeof dataForDownload !== "string" &&
+              link.href.startsWith("blob:")
+            ) {
               URL.revokeObjectURL(link.href);
             }
             console.log("📱 Standard download method executed");
@@ -925,7 +932,9 @@ Made with love ❤️ By Aral D'Souza
         link.href = url;
         const disposition = response.headers.get("content-disposition") || "";
         const match = disposition.match(/filename="?([^";]+)"?/i);
-        const serverFilename = match ? match[1] : "Aral-Violet-Wedding-Invitation.pdf";
+        const serverFilename = match
+          ? match[1]
+          : "Aral-Violet-Wedding-Invitation.pdf";
         link.download = serverFilename;
         link.target = "_blank";
 
@@ -978,7 +987,9 @@ Made with love ❤️ By Aral D'Souza
               for (let i = 0; i < byteChars.length; i++)
                 byteNums[i] = byteChars.charCodeAt(i);
               const byteArray = new Uint8Array(byteNums);
-              dataForDownload = new Blob([byteArray], { type: "application/pdf" });
+              dataForDownload = new Blob([byteArray], {
+                type: "application/pdf",
+              });
             } catch {
               dataForDownload = `data:application/pdf;base64,${dataForDownload}`;
             }
@@ -1008,7 +1019,10 @@ Made with love ❤️ By Aral D'Souza
             document.body.appendChild(link);
             link.click();
             document.body.removeChild(link);
-            if (typeof dataForDownload !== "string" && link.href.startsWith("blob:")) {
+            if (
+              typeof dataForDownload !== "string" &&
+              link.href.startsWith("blob:")
+            ) {
               URL.revokeObjectURL(link.href);
             }
           }

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -818,30 +818,38 @@ Made with love ❤️ By Aral D'Souza
             uploadedInvitation.pdf_data.length,
           );
 
-          // Validate PDF data format
-          if (!uploadedInvitation.pdf_data.startsWith("data:")) {
-            console.log(
-              "�� Invalid PDF data format, trying server endpoint...",
-            );
-            throw new Error("Invalid PDF data format");
+          // Normalize PDF data (handle both data URLs and raw base64)
+          let dataForDownload: string | Blob = uploadedInvitation.pdf_data;
+          if (
+            typeof dataForDownload === "string" &&
+            !dataForDownload.startsWith("data:")
+          ) {
+            try {
+              const base64 = dataForDownload.includes(",")
+                ? dataForDownload.split(",")[1]
+                : dataForDownload;
+              const byteChars = atob(base64);
+              const byteNums = new Array(byteChars.length);
+              for (let i = 0; i < byteChars.length; i++)
+                byteNums[i] = byteChars.charCodeAt(i);
+              const byteArray = new Uint8Array(byteNums);
+              dataForDownload = new Blob([byteArray], { type: "application/pdf" });
+            } catch {
+              dataForDownload = `data:application/pdf;base64,${dataForDownload}`;
+            }
           }
 
           // Download the uploaded PDF invitation - Mobile-friendly approach
-          console.log(
-            "📱 Attempting mobile-optimized download from database...",
-          );
+          console.log("📱 Attempting mobile-optimized download from database...");
 
           const filename =
             uploadedInvitation.filename || "Aral-Violet-Wedding-Invitation.pdf";
 
           // Use mobile-optimized download utility
-          const downloadSuccess = mobileOptimizedDownload(
-            uploadedInvitation.pdf_data,
-            {
-              filename: filename,
-              mimeType: "application/pdf",
-            },
-          );
+          const downloadSuccess = mobileOptimizedDownload(dataForDownload, {
+            filename: filename,
+            mimeType: "application/pdf",
+          });
 
           console.log("📱 Mobile download result:", downloadSuccess);
 
@@ -895,7 +903,7 @@ Made with love ❤️ By Aral D'Souza
       }
 
       // Second priority: Try the server endpoint (which has its own fallback logic)
-      console.log("🌐 Trying server endpoint as fallback...");
+      console.log("���� Trying server endpoint as fallback...");
       const isNetlify = import.meta.env.VITE_DEPLOYMENT_PLATFORM === "netlify";
       const downloadEndpoint = isNetlify
         ? "/.netlify/functions/download-invitation"
@@ -1583,7 +1591,7 @@ Please RSVP at our wedding website
                         decoding="async"
                       />
                       <p className="text-sm font-medium text-olive-700 mb-2">
-                        📸 Scan to Upload Couple Photos
+                        ���� Scan to Upload Couple Photos
                       </p>
                       <p className="text-xs text-sage-500 mb-3">
                         Point your camera here


### PR DESCRIPTION
## Purpose
Fix the invitation download issue in Homage where the uploaded PDF was not downloading correctly from the database due to improper handling of different PDF data formats.

## Code changes
- **Enhanced PDF data normalization**: Added logic to handle both data URLs and raw base64 strings from the database
- **Improved data format detection**: Check if PDF data starts with "data:" prefix and normalize accordingly
- **Added Blob conversion**: Convert raw base64 data to Blob objects for proper download handling
- **Enhanced fallback mechanisms**: Improved error handling with proper data URL formatting as fallback
- **Memory management**: Added URL.revokeObjectURL() calls to prevent memory leaks when using blob URLs
- **Server filename extraction**: Parse Content-Disposition header to use server-provided filenames
- **Unified download logic**: Consistent handling across multiple download code paths (uploaded invitation, server endpoint, API response)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 49`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c31719c24e8147c0adc074760cd808b1/neon-hub)

👀 [Preview Link](https://c31719c24e8147c0adc074760cd808b1-neon-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c31719c24e8147c0adc074760cd808b1</projectId>-->
<!--<branchName>neon-hub</branchName>-->